### PR TITLE
Add Hover Styles for Github, Twitter and LinkedIn Links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -77,7 +77,7 @@ export default function RootLayout({
                   href="https://github.com/jpsanantonio"
                   legacyBehavior
                 >
-                  <a target="_blank">
+                  <a target="_blank" className="hover:text-violet-600">
                     <GithubIcon className="w-5 h-5" />
                   </a>
                 </Link>
@@ -86,7 +86,7 @@ export default function RootLayout({
                   href="https://twitter.com/jpsanantonio"
                   legacyBehavior
                 >
-                  <a target="_blank">
+                  <a target="_blank" className="hover:text-violet-600">
                     <TwitterIcon className="w-5 h-5" />
                   </a>
                 </Link>
@@ -95,7 +95,7 @@ export default function RootLayout({
                   href="https://www.linkedin.com/in/jayvicsanantonio/"
                   legacyBehavior
                 >
-                  <a target="_blank">
+                  <a target="_blank" className="hover:text-violet-600">
                     <LinkedinIcon className="w-5 h-5" />
                   </a>
                 </Link>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Added a hover effect (changing text color to violet) for social media icons on GitHub, Twitter, and LinkedIn links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->